### PR TITLE
Bluemix integration and Consumer polling

### DIFF
--- a/messagehub.html
+++ b/messagehub.html
@@ -21,10 +21,7 @@
         <label for="node-input-topic"><i class="fa fa-save"></i> Current </label>
         <input type="text" id="node-input-topic" placeholder="Topic" style="display: inline-block; vertical-align:middle; width: 72%;"/>
     </div>
-    <div class="form-row">
-        <label for="node-input-topic"><i class="fa fa-save"></i> Poll interval </label>
-        <input type="number" id="node-input-interval" placeholder="Interval" style="display: inline-block; vertical-align:middle; width: 72%;"/>
-    </div>
+    {{extraInputs}}
     <div class="form-tips" id="node-missing-service-warning" style="display: none"><i class="fa fa-warning"></i><b> Warning:</b> There is no Message Hub service connected
     </div>
     <div class="form-tips" id="node-node-info"><i class="fa fa-book"></i><b> Tips:</b> Check out the node info tab for more information
@@ -104,16 +101,21 @@ Topic = "topic"
             });
         }
 
-        function registerNode(name, conf) {
+        function registerNode(name, conf, defaults, extraInputs) {
+            var basicDefaults = {
+                apikey: {value:"", required: true},
+                topic: {value:"", required: true},
+                kafkaresturl: {value: "https://kafka-rest-prod01.messagehub.services.us-south.bluemix.net:443", required: true}
+            };
+            for (var key in defaults) {
+                if (!defaults.hasOwnProperty(key))
+                  return;
+                basicDefaults[key] = defaults[key];
+            }
             var basicConf = {
                 category: 'function',
                 color: '#FFFFFF',
-                defaults: {
-                    interval: {value: 2000, required: true},
-                    apikey: {value:"", required: true},
-                    topic: {value:"", required: true},
-                    kafkaresturl: {value: "https://kafka-rest-prod01.messagehub.services.us-south.bluemix.net:443", required: true}
-                },
+                defaults: basicDefaults,
                 inputs: 0,
                 outputs: 0,
                 icon: "kafka.png",
@@ -142,7 +144,10 @@ Topic = "topic"
             $('<script>')
                 .attr('type', 'text/x-red')
                 .attr('data-template-name', name)
-                .text($('script[type="text/x-red"][data-template-name="messagehub"]').text())
+                .text($('script[type="text/x-red"][data-template-name="messagehub"]')
+                    .text()
+                    .replace('{{extraInputs}}', extraInputs || '')
+                )
                 .appendTo('body');
 
 
@@ -154,10 +159,21 @@ Topic = "topic"
             outputs: 0
         });
 
-        registerNode('messagehub in', {
-            inputs: 0,
-            outputs: 1
-        });
+        registerNode('messagehub in',
+            {
+                inputs: 0,
+                outputs: 1
+            },
+            {
+                interval: {value: 2000, required: true},
+            },
+            [
+                '<div class="form-row">',
+                    '<label for="node-input-topic"><i class="fa fa-save"></i> Poll interval </label>',
+                    '<input type="number" id="node-input-interval" placeholder="Interval" style="display: inline-block; vertical-align:middle; width: 72%;"/>',
+                '</div>'
+            ].join("\n")
+        );
 
     })();
 </script>

--- a/messagehub.html
+++ b/messagehub.html
@@ -1,23 +1,112 @@
-<script type="text/javascript">
-    RED.nodes.registerType('messagehub out',{
-        category: 'function',
-        color: '#FFFFFF',
-        defaults: {
-            apikey:{value:"", required: true},
-            topic: {value:"", required: true},
-            kafkaresturl: {value: "https://kafka-rest-prod01.messagehub.services.us-south.bluemix.net:443", required: true}
-        },
-        inputs:1,
-        outputs:0,
-        icon: "kafka.png",
-        align: "right",
-        label: function() {
-            return this.name||"messagehub out";
-        }
-    });
+<script type="text/x-red" data-template-name="messagehub out">
+    <div class="form-row">
+        <label for="node-input-service"><i class="fa fa-hand-o-right"></i> Bluemix Service</label>
+        <select type="text" id="node-input-service" style="display: inline-block; vertical-align:middle; width: 72%;">
+          <option value="">Select a Message Hub service instance</option>
+        </select>
+    </div>
+    <div class="form-row">
+        <label for="node-input-kafkaresturl"><i class="fa fa-save"></i> Kafka REST URL </label>
+        <input type="text" id="node-input-kafkaresturl" placeholder="Kafka REST URL" style="display: inline-block; vertical-align:middle; width: 72%;"/>
+    </div>
+    <div class="form-row">
+        <label for="node-input-apikey"><i class="fa fa-save"></i> API Key </label>
+        <input type="text" id="node-input-apikey" placeholder="API Key" style="display: inline-block; vertical-align:middle; width: 72%;"/>
+    </div>
+    <div class="form-row">
+        <label for="node-input-topics"><i class="fa fa-hand-o-right"></i> Topics </label>
+        <select type="text" id="node-input-topics" style="display: inline-block; vertical-align:middle; width: 72%;">
+        </select>
+    </div>
+    <div class="form-row">
+        <label for="node-input-topic"><i class="fa fa-save"></i> Current </label>
+        <input type="text" id="node-input-topic" placeholder="Topic" style="display: inline-block; vertical-align:middle; width: 72%;"/>
+    </div>
+    <div class="form-tips" id="node-missing-service-warning" style="display: none"><i class="fa fa-warning"></i><b> Warning:</b> There is no Message Hub service connected
+    </div>
+    <div class="form-tips" id="node-node-info"><i class="fa fa-book"></i><b> Tips:</b> Check out the node info tab for more information
+    </div>
 </script>
 
-<script type="text/x-red" data-template-name="messagehub out">
+<script type="text/javascript">
+    (function() {
+        function updateTopicList(node) {
+            var serviceSelect = $('#node-input-service'),
+                topicsSelect = $('#node-input-topics');
+
+            topicsSelect.empty();
+            $.getJSON('message-hub/service/'+serviceSelect.val()+'/topics', function(topics) {
+                $.each(topics, function(index, topic) {
+                    topicsSelect.append('<option value="' + topic.name + '">' + topic.name + '</option>');
+                });
+
+                topicsSelect.find('option')
+                    .filter(function() { return $(this).val() === node.topics; })
+                    .attr('selected', true);
+
+            });
+        }
+
+        function oneditprepare() {
+            var node = this;
+
+            $.getJSON('message-hub/vcap/', function(services) {
+                var select = $('#node-input-service'),
+                    topicsSelect = $('#node-input-topics');
+
+                if (services.length == 0)
+                    return $("#node-missing-service-warning").show();
+
+                for (var i = 0, service; service = services[i]; i++) {
+                    select.append('<option value="' + service.name + '">' + service.name + '</option>');
+                }
+
+                select.find("option")
+                    .filter(function() { return $(this).val() === node.service; })
+                    .attr('selected', true);
+
+                select.change(function() {
+                    var serviceName = $(this).val(),
+                        service = services.find(function(s) { return s.name === serviceName; });
+                    if (service) {
+                        $("#node-input-kafkaresturl").val(service.credentials.kafka_rest_url);
+                        $("#node-input-apikey").val(service.credentials.api_key);
+                        updateTopicList(node);
+                    }
+                });
+
+                topicsSelect.change(function() {
+                    $('#node-input-topic').val($(this).val());
+                });
+                updateTopicList(node);
+            });
+        }
+
+        RED.nodes.registerType('messagehub out',{
+            category: 'function',
+            color: '#FFFFFF',
+            defaults: {
+                apikey: {value:"", required: true},
+                topic: {value:"", required: true},
+                kafkaresturl: {value: "https://kafka-rest-prod01.messagehub.services.us-south.bluemix.net:443", required: true}
+            },
+            inputs:1,
+            outputs:0,
+            icon: "kafka.png",
+            align: "right",
+            label: function() {
+                return this.name || "messagehub out";
+            },
+            labelStyle: function() {
+                return this.name ? "node_label_italic" : "";
+            },
+            oneditprepare: oneditprepare
+        });
+
+    })();
+</script>
+
+<!--script type="text/x-red" data-template-name="messagehub out">
     <div class="form-row">
         <label for="node-input-apikey"><i class="icon-tag"></i>API Key</label>
         <input type="text" id="node-input-apikey" placeholder="API Key">
@@ -32,7 +121,7 @@
         <label for="node-input-topic"><i class="icon-tag"></i>Topic</label>
         <input type="text" id="node-input-topic" placeholder="Topic">
     </div>
-</script>
+</script-->
 
 <script type="text/x-red" data-help-name="messagehub out">
     <p>A simple Message Hub producer node.</p>

--- a/messagehub.html
+++ b/messagehub.html
@@ -1,4 +1,4 @@
-<script type="text/x-red" data-template-name="messagehub out">
+<script type="text/x-red" data-template-name="messagehub">
     <div class="form-row">
         <label for="node-input-service"><i class="fa fa-hand-o-right"></i> Bluemix Service</label>
         <select type="text" id="node-input-service" style="display: inline-block; vertical-align:middle; width: 72%;">
@@ -15,17 +15,31 @@
     </div>
     <div class="form-row">
         <label for="node-input-topics"><i class="fa fa-hand-o-right"></i> Topics </label>
-        <select type="text" id="node-input-topics" style="display: inline-block; vertical-align:middle; width: 72%;">
-        </select>
+        <select type="text" id="node-input-topics" style="display: inline-block; vertical-align:middle; width: 72%;"></select>
     </div>
     <div class="form-row">
         <label for="node-input-topic"><i class="fa fa-save"></i> Current </label>
         <input type="text" id="node-input-topic" placeholder="Topic" style="display: inline-block; vertical-align:middle; width: 72%;"/>
     </div>
+    <div class="form-row">
+        <label for="node-input-topic"><i class="fa fa-save"></i> Poll interval </label>
+        <input type="number" id="node-input-interval" placeholder="Interval" style="display: inline-block; vertical-align:middle; width: 72%;"/>
+    </div>
     <div class="form-tips" id="node-missing-service-warning" style="display: none"><i class="fa fa-warning"></i><b> Warning:</b> There is no Message Hub service connected
     </div>
     <div class="form-tips" id="node-node-info"><i class="fa fa-book"></i><b> Tips:</b> Check out the node info tab for more information
     </div>
+</script>
+
+<script type="text/x-red" data-help-name="messagehub">
+<p>A simple Message Hub consumer node.</p>
+<p><b>API Key</b> <i>The API Key provided by the Message Hub Service</i>. The service will not be automatically created, you need to go to Bluemix and activate the Message Hub Service in the Catalog section.</p>
+<p><b>Kafka REST URL</b> <i>The full URL of the Kafka REST URL provided by the Message Hub Service. Once the service has been provisioned on Bluemix, go to credentials and get your REST API URL.</p>
+<p><b>Topic</b> <i>The topic of message to produce. Please be aware that Message Hub charges by topic.</i></p>
+<pre>
+Example:
+Topic = "topic"
+</pre>
 </script>
 
 <script type="text/javascript">
@@ -35,7 +49,15 @@
                 topicsSelect = $('#node-input-topics');
 
             topicsSelect.empty();
+
+            if (!serviceSelect.val())
+                return;
+
+            topicsSelect.append('<option value="">Loading</option>');
+
             $.getJSON('message-hub/service/'+serviceSelect.val()+'/topics', function(topics) {
+                topicsSelect.empty()
+                topicsSelect.append('<option value="">Select Topic</option>');
                 $.each(topics, function(index, topic) {
                     topicsSelect.append('<option value="' + topic.name + '">' + topic.name + '</option>');
                 });
@@ -82,100 +104,60 @@
             });
         }
 
-        RED.nodes.registerType('messagehub out',{
-            category: 'function',
-            color: '#FFFFFF',
-            defaults: {
-                apikey: {value:"", required: true},
-                topic: {value:"", required: true},
-                kafkaresturl: {value: "https://kafka-rest-prod01.messagehub.services.us-south.bluemix.net:443", required: true}
-            },
-            inputs:1,
-            outputs:0,
-            icon: "kafka.png",
-            align: "right",
-            label: function() {
-                return this.name || "messagehub out";
-            },
-            labelStyle: function() {
-                return this.name ? "node_label_italic" : "";
-            },
-            oneditprepare: oneditprepare
+        function registerNode(name, conf) {
+            var basicConf = {
+                category: 'function',
+                color: '#FFFFFF',
+                defaults: {
+                    interval: {value: 2000, required: true},
+                    apikey: {value:"", required: true},
+                    topic: {value:"", required: true},
+                    kafkaresturl: {value: "https://kafka-rest-prod01.messagehub.services.us-south.bluemix.net:443", required: true}
+                },
+                inputs: 0,
+                outputs: 0,
+                icon: "kafka.png",
+                align: "right",
+                label: function() {
+                    return this.name || name;
+                },
+                labelStyle: function() {
+                    return this.name ? "node_label_italic" : "";
+                },
+                oneditprepare: oneditprepare
+            }
+
+            for (key in conf) {
+                if (!conf.hasOwnProperty(key))
+                    continue
+                basicConf[key] = conf[key];
+            }
+
+            $('<script>')
+                .attr('type', 'text/x-red')
+                .attr('data-help-name', name)
+                .text($('script[type="text/x-red"][data-help-name="messagehub"]').text())
+                .appendTo('body');
+
+            $('<script>')
+                .attr('type', 'text/x-red')
+                .attr('data-template-name', name)
+                .text($('script[type="text/x-red"][data-template-name="messagehub"]').text())
+                .appendTo('body');
+
+
+            RED.nodes.registerType(name, basicConf);
+        }
+
+        registerNode('messagehub out', {
+            inputs: 1,
+            outputs: 0
+        });
+
+        registerNode('messagehub in', {
+            inputs: 0,
+            outputs: 1
         });
 
     })();
-</script>
-
-<!--script type="text/x-red" data-template-name="messagehub out">
-    <div class="form-row">
-        <label for="node-input-apikey"><i class="icon-tag"></i>API Key</label>
-        <input type="text" id="node-input-apikey" placeholder="API Key">
-    </div>
-
-    <div class="form-row">
-        <label for="node-input-kafkaresturl"><i class="icon-tag"></i>Kafka REST URL</label>
-        <input type="text" id="node-input-kafkaresturl" placeholder="Kafka REST URL">
-    </div>
-
-    <div class="form-row">
-        <label for="node-input-topic"><i class="icon-tag"></i>Topic</label>
-        <input type="text" id="node-input-topic" placeholder="Topic">
-    </div>
-</script-->
-
-<script type="text/x-red" data-help-name="messagehub out">
-    <p>A simple Message Hub producer node.</p>
-    <p><b>API Key</b> <i>The API Key provided by the Message Hub Service</i>. The service will not be automatically created, you need to go to Bluemix and activate the Message Hub Service in the Catalog section.</p>
-    <p><b>Kafka REST URL</b> <i>The full URL of the Kafka REST URL provided by the Message Hub Service. Once the service has been provisioned on Bluemix, go to credentials and get your REST API URL.</p>
-    <p><b>Topic</b> <i>The topic of message to produce. Please be aware that Message Hub charges by topic.</i></p>
-    <pre>
-Example:
-Topic = "topic"
-    </pre>
-</script>
-
-<script type="text/javascript">
-    RED.nodes.registerType('messagehub in',{
-        category: 'function',
-        color: '#FFFFFF',
-        defaults: {
-            apikey:{value:"", required: true},
-            topic: {value:"", required: true},
-            kafkaresturl: {value: "https://kafka-rest-prod01.messagehub.services.us-south.bluemix.net:443", required: true}
-        },
-        inputs:0,
-        outputs:1,
-        icon: "kafka.png",
-        label: function() {
-          return this.name||"messagehub in";
-        }
-    });
-</script>
-
-<script type="text/x-red" data-template-name="messagehub in">
-  <div class="form-row">
-      <label for="node-input-apikey"><i class="icon-tag"></i>API Key</label>
-      <input type="text" id="node-input-apikey" placeholder="API Key">
-  </div>
-
-  <div class="form-row">
-      <label for="node-input-kafkaresturl"><i class="icon-tag"></i>Kafka REST URL</label>
-      <input type="text" id="node-input-kafkaresturl" placeholder="Kafka REST URL">
-  </div>
-
-  <div class="form-row">
-      <label for="node-input-topic"><i class="icon-tag"></i>Topic</label>
-      <input type="text" id="node-input-topic" placeholder="Topic">
-  </div>
-</script>
-
-<script type="text/x-red" data-help-name="messagehub in">
-<p>A simple Message Hub consumer node.</p>
-<p><b>API Key</b> <i>The API Key provided by the Message Hub Service</i>. The service will not be automatically created, you need to go to Bluemix and activate the Message Hub Service in the Catalog section.</p>
-<p><b>Kafka REST URL</b> <i>The full URL of the Kafka REST URL provided by the Message Hub Service. Once the service has been provisioned on Bluemix, go to credentials and get your REST API URL.</p>
-<p><b>Topic</b> <i>The topic of message to produce. Please be aware that Message Hub charges by topic.</i></p>
-<pre>
-Example:
-Topic = "topic"
-</pre>
 </script>

--- a/messagehub.html
+++ b/messagehub.html
@@ -1,17 +1,87 @@
+<script type="text/x-red" data-help-name="messagehub service">
+<p>Message Hub service</p>
+<p><b>API Key</b> <i>The API Key provided by the Message Hub Service</i>. The service will not be automatically created, you need to go to Bluemix and activate the Message Hub Service in the Catalog section.</p>
+<p><b>Kafka REST URL</b> <i>The full URL of the Kafka REST URL provided by the Message Hub Service. Once the service has been provisioned on Bluemix, go to credentials and get your REST API URL.</p>
+<p>Although, values are tried to be taken of the <pre>VCAP_SERVICE</pre> environmental variable, the user can write them.</p>
+</script>
+
+<script type="text/x-red" data-template-name="messagehub service">
+    <div class="form-row">
+        <label for="node-config-input-service"><i class="fa fa-hand-o-right"></i> Bluemix Service</label>
+        <select type="text" id="node-config-input-service" style="display: inline-block; vertical-align:middle; width: 72%;">
+            <option value="">Loading</option>
+        </select>
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-kafkaRestUrl"><i class="fa fa-save"></i> Kafka REST URL </label>
+        <input type="text" id="node-config-input-kafkaRestUrl" placeholder="Kafka REST URL" style="display: inline-block; vertical-align:middle; width: 72%;"/>
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-apiKey"><i class="fa fa-save"></i> API Key </label>
+        <input type="text" id="node-config-input-apiKey" placeholder="API Key" style="display: inline-block; vertical-align:middle; width: 72%;"/>
+    </div>
+    <div class="form-tips" id="node-missing-service-warning" style="display: none"><i class="fa fa-warning"></i><b> Warning:</b> There is no Message Hub service connected
+    </div>
+    <div class="form-tips" id="node-node-info"><i class="fa fa-book"></i><b> Tips:</b> Check out the node info tab for more information
+    </div>
+</script>
+
+<script type="text/javascript">
+(function() {
+    function oneditprepare() {
+        var node = this;
+
+        $.getJSON('message-hub/vcap/', function(services) {
+            var select = $('#node-config-input-service');
+            select.empty();
+
+            if (services.length == 0)
+                return $("#node-missing-service-warning").show();
+
+            select.append('<option value="">Select a Message Hub service instance</option>');
+
+            for (var i = 0, service; service = services[i]; i++) {
+                select.append('<option value="' + service.name + '">' + service.name + '</option>');
+            }
+
+            select.find("option")
+                .filter(function() { return $(this).val() === node.service; })
+                .attr('selected', true);
+
+            select.change(function() {
+                var serviceName = $(this).val(),
+                    service = services.find(function(s) { return s.name === serviceName; });
+                if (service) {
+                    $("#node-config-input-kafkaRestUrl").val(service.credentials.kafka_rest_url);
+                    $("#node-config-input-apiKey").val(service.credentials.api_key);
+                }
+            });
+        });
+    }
+
+    RED.nodes.registerType("messagehub service", {
+        category: 'config',
+        defaults: {
+            kafkaRestUrl: {value: 'https://kafka-rest-prod01.messagehub.services.us-south.bluemix.net:443', required: true},
+            service: {value: ''}
+        },
+        credentials: {
+            apiKey: {type: 'text'}
+        },
+        label: function() {
+            return this.service || this.kafkaRestUrl;
+        },
+        oneditprepare: oneditprepare
+    });
+})()
+</script>
+
 <script type="text/x-red" data-template-name="messagehub">
     <div class="form-row">
         <label for="node-input-service"><i class="fa fa-hand-o-right"></i> Bluemix Service</label>
         <select type="text" id="node-input-service" style="display: inline-block; vertical-align:middle; width: 72%;">
           <option value="">Select a Message Hub service instance</option>
         </select>
-    </div>
-    <div class="form-row">
-        <label for="node-input-kafkaresturl"><i class="fa fa-save"></i> Kafka REST URL </label>
-        <input type="text" id="node-input-kafkaresturl" placeholder="Kafka REST URL" style="display: inline-block; vertical-align:middle; width: 72%;"/>
-    </div>
-    <div class="form-row">
-        <label for="node-input-apikey"><i class="fa fa-save"></i> API Key </label>
-        <input type="text" id="node-input-apikey" placeholder="API Key" style="display: inline-block; vertical-align:middle; width: 72%;"/>
     </div>
     <div class="form-row">
         <label for="node-input-topics"><i class="fa fa-hand-o-right"></i> Topics </label>
@@ -29,14 +99,13 @@
 </script>
 
 <script type="text/x-red" data-help-name="messagehub">
-<p>A simple Message Hub consumer node.</p>
-<p><b>API Key</b> <i>The API Key provided by the Message Hub Service</i>. The service will not be automatically created, you need to go to Bluemix and activate the Message Hub Service in the Catalog section.</p>
-<p><b>Kafka REST URL</b> <i>The full URL of the Kafka REST URL provided by the Message Hub Service. Once the service has been provisioned on Bluemix, go to credentials and get your REST API URL.</p>
+<p>Message Hub</p>
 <p><b>Topic</b> <i>The topic of message to produce. Please be aware that Message Hub charges by topic.</i></p>
 <pre>
 Example:
 Topic = "topic"
 </pre>
+<p><b>Interval</b> <i>The poll interval of the producer</i></p>
 </script>
 
 <script type="text/javascript">
@@ -47,12 +116,29 @@ Topic = "topic"
 
             topicsSelect.empty();
 
-            if (!serviceSelect.val())
+            var serviceNodeId = serviceSelect.val();
+            if (!serviceNodeId)
                 return;
+
+            var serviceNode;
+            RED.nodes.eachConfig(function(c) {
+                if (c.id === serviceNodeId)
+                    serviceNode = c;
+            });
+
+            if (!serviceNode)
+                return;
+
+            var kafkaRestUrl = serviceNode.kafkaRestUrl;
+            var apiKey = (serviceNode.credentials || {}).apiKey;
+            var url = encodeURIComponent(serviceNodeId);
+
+            if (kafkaRestUrl && apiKey)
+                url = encodeURIComponent(kafkaRestUrl)+'/'+encodeURIComponent(apiKey);
 
             topicsSelect.append('<option value="">Loading</option>');
 
-            $.getJSON('message-hub/service/'+serviceSelect.val()+'/topics', function(topics) {
+            $.getJSON('message-hub/service/'+url+'/topics', function(topics) {
                 topicsSelect.empty()
                 topicsSelect.append('<option value="">Select Topic</option>');
                 $.each(topics, function(index, topic) {
@@ -60,7 +146,7 @@ Topic = "topic"
                 });
 
                 topicsSelect.find('option')
-                    .filter(function() { return $(this).val() === node.topics; })
+                    .filter(function() { return $(this).val() === node.topic; })
                     .attr('selected', true);
 
             });
@@ -68,44 +154,17 @@ Topic = "topic"
 
         function oneditprepare() {
             var node = this;
+            updateTopicList(node);
 
-            $.getJSON('message-hub/vcap/', function(services) {
-                var select = $('#node-input-service'),
-                    topicsSelect = $('#node-input-topics');
-
-                if (services.length == 0)
-                    return $("#node-missing-service-warning").show();
-
-                for (var i = 0, service; service = services[i]; i++) {
-                    select.append('<option value="' + service.name + '">' + service.name + '</option>');
-                }
-
-                select.find("option")
-                    .filter(function() { return $(this).val() === node.service; })
-                    .attr('selected', true);
-
-                select.change(function() {
-                    var serviceName = $(this).val(),
-                        service = services.find(function(s) { return s.name === serviceName; });
-                    if (service) {
-                        $("#node-input-kafkaresturl").val(service.credentials.kafka_rest_url);
-                        $("#node-input-apikey").val(service.credentials.api_key);
-                        updateTopicList(node);
-                    }
-                });
-
-                topicsSelect.change(function() {
-                    $('#node-input-topic').val($(this).val());
-                });
+            $('#node-input-service').change(function() {
                 updateTopicList(node);
             });
         }
 
         function registerNode(name, conf, defaults, extraInputs) {
             var basicDefaults = {
-                apikey: {value:"", required: true},
-                topic: {value:"", required: true},
-                kafkaresturl: {value: "https://kafka-rest-prod01.messagehub.services.us-south.bluemix.net:443", required: true}
+                service: {value:"", required: true, type: 'messagehub service'},
+                topic: {value:"", required: true}
             };
             for (var key in defaults) {
                 if (!defaults.hasOwnProperty(key))
@@ -165,7 +224,7 @@ Topic = "topic"
                 outputs: 1
             },
             {
-                interval: {value: 2000, required: true},
+                interval: {value: 2000, required: true, validate: RED.validators.number()},
             },
             [
                 '<div class="form-row">',

--- a/messagehub.html
+++ b/messagehub.html
@@ -8,17 +8,17 @@
 <script type="text/x-red" data-template-name="messagehub service">
     <div class="form-row">
         <label for="node-config-input-service"><i class="fa fa-hand-o-right"></i> Bluemix Service</label>
-        <select type="text" id="node-config-input-service" style="display: inline-block; vertical-align:middle; width: 72%;">
+        <select type="text" id="node-config-input-service">
             <option value="">Loading</option>
         </select>
     </div>
     <div class="form-row">
         <label for="node-config-input-kafkaRestUrl"><i class="fa fa-save"></i> Kafka REST URL </label>
-        <input type="text" id="node-config-input-kafkaRestUrl" placeholder="Kafka REST URL" style="display: inline-block; vertical-align:middle; width: 72%;"/>
+        <input type="text" id="node-config-input-kafkaRestUrl" placeholder="Kafka REST URL" />
     </div>
     <div class="form-row">
         <label for="node-config-input-apiKey"><i class="fa fa-save"></i> API Key </label>
-        <input type="text" id="node-config-input-apiKey" placeholder="API Key" style="display: inline-block; vertical-align:middle; width: 72%;"/>
+        <input type="text" id="node-config-input-apiKey" placeholder="API Key" />
     </div>
     <div class="form-tips" id="node-missing-service-warning" style="display: none"><i class="fa fa-warning"></i><b> Warning:</b> There is no Message Hub service connected
     </div>
@@ -48,14 +48,17 @@
                 .filter(function() { return $(this).val() === node.service; })
                 .attr('selected', true);
 
-            select.change(function() {
+            function onChange() {
                 var serviceName = $(this).val(),
                     service = services.find(function(s) { return s.name === serviceName; });
                 if (service) {
                     $("#node-config-input-kafkaRestUrl").val(service.credentials.kafka_rest_url);
                     $("#node-config-input-apiKey").val(service.credentials.api_key);
                 }
-            });
+            }
+
+            select.change(onChange);
+            onChage.call(select);
         });
     }
 
@@ -77,6 +80,10 @@
 </script>
 
 <script type="text/x-red" data-template-name="messagehub">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name </label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
     <div class="form-row">
         <label for="node-input-service"><i class="fa fa-hand-o-right"></i> Bluemix Service</label>
         <select type="text" id="node-input-service" style="display: inline-block; vertical-align:middle; width: 72%;">
@@ -100,12 +107,13 @@
 
 <script type="text/x-red" data-help-name="messagehub">
 <p>Message Hub</p>
-<p><b>Topic</b> <i>The topic of message to produce. Please be aware that Message Hub charges by topic.</i></p>
+<p>A simple <i>Message Hub<i> node. Sends or recibe (<code>msg.payload</code>) to/from the chosen queue.</p>
+<p><b>Topic</b> The topic of message to produce. Please be aware that Message Hub charges by topic.</p>
 <pre>
 Example:
 Topic = "topic"
 </pre>
-<p><b>Interval</b> <i>The poll interval of the producer</i></p>
+{{extraHelp}}
 </script>
 
 <script type="text/javascript">
@@ -161,8 +169,9 @@ Topic = "topic"
             });
         }
 
-        function registerNode(name, conf, defaults, extraInputs) {
+        function registerNode(name, conf, defaults, extraInputs, extraHelp) {
             var basicDefaults = {
+                name: {value: ""},
                 service: {value:"", required: true, type: 'messagehub service'},
                 topic: {value:"", required: true}
             };
@@ -197,7 +206,10 @@ Topic = "topic"
             $('<script>')
                 .attr('type', 'text/x-red')
                 .attr('data-help-name', name)
-                .text($('script[type="text/x-red"][data-help-name="messagehub"]').text())
+                .text($('script[type="text/x-red"][data-help-name="messagehub"]')
+                    .text()
+                    .replace('{{extraHelp}}', extraHelp || '')
+                )
                 .appendTo('body');
 
             $('<script>')
@@ -213,10 +225,33 @@ Topic = "topic"
             RED.nodes.registerType(name, basicConf);
         }
 
-        registerNode('messagehub out', {
-            inputs: 1,
-            outputs: 0
-        });
+        registerNode('messagehub out',
+            {
+                inputs: 1,
+                outputs: 0,
+                oneditprepare: function() {
+                    var node = this;
+                    $('#node-input-successOutput').change(function() {
+                        node.outputs = $(this).is(':checked') ? 1 : 0;
+                    });
+
+                    if (this.successOutput)
+                        this.outputs = 1;
+
+                    return oneditprepare.call(this);
+                }
+            },
+            {
+                successOutput: {value: false}
+            },
+            [
+                '<div class="form-row">',
+                    '<label for="node-input-topic"><i class="fa fa-sign-out"></i> Success output </label>',
+                    '<input type="checkbox" id="node-input-successOutput"/>',
+                '</div>'
+            ].join("\n"),
+            '<p><b>Success output</b> <i>If true adds an output, where message are sent on success</i></p>'
+        );
 
         registerNode('messagehub in',
             {
@@ -229,9 +264,10 @@ Topic = "topic"
             [
                 '<div class="form-row">',
                     '<label for="node-input-topic"><i class="fa fa-save"></i> Poll interval </label>',
-                    '<input type="number" id="node-input-interval" placeholder="Interval" style="display: inline-block; vertical-align:middle; width: 72%;"/>',
+                    '<input type="number" id="node-input-interval" placeholder="Interval"/>',
                 '</div>'
-            ].join("\n")
+            ].join("\n"),
+            '<p><b>Interval</b> <i>The poll interval of the producer</i></p>'
         );
 
     })();

--- a/messagehub.js
+++ b/messagehub.js
@@ -192,7 +192,7 @@ module.exports = function(RED) {
         })
         .then(function(consumerInstance) {
           node.log("Consumer created...");
-          this.status({fill:"green", shape:"ring", text:"Connected"});
+          node.status({fill:"green", shape:"ring", text:"Connected"});
           return getTopicAndSend(consumerInstance)
         })
         .fail(function(error) {
@@ -201,7 +201,7 @@ module.exports = function(RED) {
         });
     } catch(e) {
       node.error(e);
-      this.status({fill:"red", shape:"ring", text:"Error while consuming"});
+      node.status({fill:"red", shape:"ring", text:"Error while consuming"});
     }
 
     this.on('close', function() {

--- a/messagehub.js
+++ b/messagehub.js
@@ -110,7 +110,6 @@ module.exports = function(RED) {
       try {
         var payloads = [];
 
-        node.log(msg.payload);
         payloads.push(msg.payload);
 
         var list = new MessageHub.MessageList(payloads);

--- a/messagehub.js
+++ b/messagehub.js
@@ -1,38 +1,52 @@
 /**
  * Created by fwang1 on 3/25/15.
  */
+
+var MessageHub = require('message-hub-rest');
+var Q = require('q');
+
+function createServices(config) {
+  return {
+    "messagehub": [
+      {
+        "credentials": {
+          "api_key":  config.apikey,
+          "kafka_rest_url": config.kafkaresturl
+        }
+      }
+    ]
+  }
+}
+
 module.exports = function(RED) {
-    var MessageHub = require('message-hub-rest'),
-        vcap = JSON.parse(process.env.VCAP_SERVICES || "{}"),
-        services = null,
-        servicesList = null;
-    services = vcap["messagehub"] || [];
+    var vcap = JSON.parse(process.env.VCAP_SERVICES || "{}");
+    var services = vcap["messagehub"] || [];
 
     // make these names available to the node configuration
     RED.httpAdmin.get('/message-hub/vcap', function(req, res) {
-        res.json(services);
+      res.json(services);
     });
 
     RED.httpAdmin.get('/message-hub/service/:serviceSelectedVal/topics', function(req, res) {
-        var serviceSelectedVal = decodeURIComponent(req.params.serviceSelectedVal),
-            selectedService = services.find(function(service) {
-                return service.name == serviceSelectedVal;
-            });
-
-        if (!selectedService)
-            return res.json([]);
-
-        var instance = new MessageHub({
-            messagehub: [selectedService]
+      var serviceSelectedVal = decodeURIComponent(req.params.serviceSelectedVal),
+        selectedService = services.find(function(service) {
+            return service.name == serviceSelectedVal;
         });
 
-        instance.topics.get()
-          .then(function(response) {
-              res.json(response);
-          })
-          .fail(function(error) {
-              res.json(error)
-          });
+      if (!selectedService)
+        return res.json([]);
+
+      var instance = new MessageHub({
+        messagehub: [selectedService]
+      });
+
+      instance.topics.get()
+        .then(function(response) {
+          res.json(response);
+        })
+        .fail(function(error) {
+          res.json(error)
+        });
     });
 
   /*
@@ -42,19 +56,7 @@ module.exports = function(RED) {
     RED.nodes.createNode(this, config);
 
     var node = this;
-
-    var apikey = config.apikey;
-    var kafka_rest_url = config.kafkaresturl;
-    var services = {
-      "messagehub": [
-        {
-          "credentials": {
-            "api_key": apikey,
-            "kafka_rest_url": kafka_rest_url
-          }
-        }
-      ]
-    }
+    var services = createServices(config);
 
     var instance = new MessageHub(services);
     var topic = config.topic;
@@ -70,8 +72,8 @@ module.exports = function(RED) {
 
         instance.produce(topic, list.messages)
         .then(function(data) {
-          node.log("Message sent");
-          node.log(data);
+          node.debug("Message sent");
+          node.debug(data);
         })
         .fail(function(error) {
           node.error(error);
@@ -92,54 +94,52 @@ module.exports = function(RED) {
     RED.nodes.createNode(this,config);
 
     var node = this;
-    var apikey = config.apikey;
-    var kafka_rest_url = config.kafkaresturl;
-    var services = {
-      "messagehub": [
-        {
-          "credentials": {
-            "api_key": apikey,
-            "kafka_rest_url": kafka_rest_url
-          }
-        }
-      ]
-    }
+    var interval = parseInt(config.interval) || 2000;
+    var services = createServices(config);
 
     var instance = new MessageHub(services);
     var topic = config.topic;
-    var consumerInstance;
 
     function random() {
       return Math.floor((Math.random() * 100) + 1);
     }
 
-    node.log(topic);
-    instance.consume('nodered-' + topic + "-" + random(), 'nodered', { 'auto.offset.reset': 'largest' })
-    .then(function(response) {
-      consumerInstance = response[0];
-    })
-    .fail(function(error) {
-      node.error(error);
-    });
-
-    try {
-      this.log("Consumer created...");
-      setInterval(function() {
-        consumerInstance.get(topic)
+    function getTopicAndSend(consumerInstance) {
+      var lastCheck = Date.now();
+      return consumerInstance
+        .get(topic)
         .then(function(data) {
-          for(var i=0; i<data.length; i++) {
+          for (var i=0; i < data.length; i++) {
             node.send({payload: data[i]});
           }
         })
         .fail(function(err) {
           node.error(err);
+        })
+        .then(function() {
+          var deferred = Q.defer();
+          var waitMsec = interval - (Date.now() - lastCheck);
+          setTimeout(function() {
+            deferred.resolve(getTopicAndSend(consumerInstance));
+          }, waitMsec > 0 ? waitMsec : 0)
+          return deferred.promise;
         });
-      }, 2000);
     }
-    catch(e){
-      node.error(e);
-      return;
-    }
+
+    node.log('Creating consumer for topic: \'' + topic + '\'');
+
+    instance
+      .consume('nodered-' + topic + "-" + random(), 'nodered', { 'auto.offset.reset': 'largest' })
+      .then(function(response) {
+        return response[0];
+      })
+      .then(function(consumerInstance) {
+        node.log("Consumer created...");
+        return getTopicAndSend(consumerInstance)
+      })
+      .fail(function(error) {
+        node.error(error);
+      });
   }
 
   RED.nodes.registerType("messagehub in", MessageHubConsumer);

--- a/messagehub.js
+++ b/messagehub.js
@@ -192,12 +192,13 @@ module.exports = function(RED) {
         })
         .then(function(consumerInstance) {
           node.log("Consumer created...");
+          this.status({fill:"green", shape:"ring", text:"Connected"});
           return getTopicAndSend(consumerInstance)
         })
         .fail(function(error) {
-          node.error('Error creating cosumer', {error: error});
+          node.status({fill:"red", shape:"ring", text: error.message});
+          node.error('Error creating consumer', {error: error});
         });
-      this.status({fill:"green", shape:"ring", text:"Connected"});
     } catch(e) {
       node.error(e);
       this.status({fill:"red", shape:"ring", text:"Error while consuming"});

--- a/messagehub.js
+++ b/messagehub.js
@@ -116,10 +116,6 @@ module.exports = function(RED) {
         var list = new MessageHub.MessageList(payloads);
 
         instance.produce(topic, list.messages)
-          .then(function(data) {
-            node.debug("Message sent");
-            node.debug(data);
-          })
           .fail(function(error) {
             node.error(error);
           });

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.2",
   "description": "Node-RED nodes of HighLevel MessageHub Producer and Consumer",
   "dependencies": {
-    "message-hub-rest": "^1.1.2"
+    "message-hub-rest": "^1.1.2",
+    "q": "^1.4.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     }
   },
   "author": {
-    "name": "IBM",
+    "name": "IBM"
   },
   "maintainers": [
     {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.2",
   "description": "Node-RED nodes of HighLevel MessageHub Producer and Consumer",
   "dependencies": {
+    "cfenv": "^1.0.4",
     "message-hub-rest": "^1.1.2",
     "q": "^1.4.1"
   },


### PR DESCRIPTION
This PR adds the use of the environmental variable `VCAP_SERVICES` in order to autodetect bluemix configuration.

In addition, it fixes how the consumer polls. In the previous implementation (using `setInterval`), when node-red was run under slow internet connections (if the http request for the message lasts more than the default interval of 2000msec), messages arrived duplicated.

The new implementation waits for the previous request to finish, in order to make a new query for messages.