### PR TITLE
Created reconnection timeouts for Message Hub Consumer instance

### DIFF
--- a/messagehub.js
+++ b/messagehub.js
@@ -145,11 +145,11 @@ module.exports = function(RED) {
     RED.nodes.createNode(this,config);
 
     var node = this;
-    node.loop = true;
     var interval = parseInt(config.interval) || 2000;
     var service = RED.nodes.getNode(config.service);
 
-    var instance = new MessageHub(service.getService());
+    var instance
+    var timeout
     var topic = config.topic;
 
     function random() {
@@ -158,6 +158,7 @@ module.exports = function(RED) {
 
     function getTopicAndSend(consumerInstance) {
       var lastCheck = Date.now();
+
       if (!node.loop)
         return;
 
@@ -169,7 +170,9 @@ module.exports = function(RED) {
           }
         })
         .fail(function(err) {
-          node.error("Error getting topic: '"+topic+"' has failed", {error: err});
+          node.error("Error getting topic: '"+topic+"' has failed.  Retrying in 1 minute.", {error: err});
+          node.loop = false
+          timeout = setTimeout(connectConsumer,360000)
         })
         .then(function() {
           var deferred = Q.defer();
@@ -182,31 +185,44 @@ module.exports = function(RED) {
         });
     }
 
-    node.log('Creating consumer for topic: \'' + topic + '\'');
+    function connectConsumer(){
+      node.log('Creating consumer for topic: \'' + topic + '\'');
 
-    try {
-      instance
-        .consume('nodered-' + topic + "-" + random(), 'nodered', { 'auto.offset.reset': 'largest' })
-        .then(function(response) {
-          return response[0];
-        })
-        .then(function(consumerInstance) {
-          node.log("Consumer created...");
-          node.status({fill:"green", shape:"ring", text:"Connected"});
-          return getTopicAndSend(consumerInstance)
-        })
-        .fail(function(error) {
-          node.status({fill:"red", shape:"ring", text: error.message});
-          node.error('Error creating consumer', {error: error});
-        });
-    } catch(e) {
-      node.error(e);
-      node.status({fill:"red", shape:"ring", text:"Error while consuming"});
+      instance = new MessageHub(service.getService());
+      node.consumerConnected = false
+      timeout = setTimeout(() => {if(!node.consumerConnected)connectConsumer()},360000)
+      try {
+        instance
+          .consume('nodered-' + topic + "-" + random(), 'nodered', { 'auto.offset.reset': 'largest' })
+          .then(function(response) {
+            return response[0];
+          })
+          .then(function(consumerInstance) {
+            node.log("Consumer created...");
+            node.status({fill:"green", shape:"ring", text:"Connected"});
+            node.loop = true
+            node.consumerConnected = true
+            return getTopicAndSend(consumerInstance)
+          })
+          .fail(function(error) {
+            node.status({fill:"red", shape:"ring", text: error.message});
+            node.error('Error creating consumer. Retrying in 1 minute.', {error: error});
+            timeout = setTimeout(connectConsumer,360000)
+          });
+      } catch(e) {
+        node.error(e);
+        node.status({fill:"red", shape:"ring", text:"Error while consuming.  Retrying in 1 minute."});
+        timeout = setTimeout(connectConsumer,360000)
+      }
     }
+
+    connectConsumer()
 
     this.on('close', function() {
       node.loop = false;
+      clearTimeout(timeout);
     });
+
   }
 
   RED.nodes.registerType("messagehub in", MessageHubConsumer);

--- a/messagehub.js
+++ b/messagehub.js
@@ -172,7 +172,7 @@ module.exports = function(RED) {
         .fail(function(err) {
           node.error("Error getting topic: '"+topic+"' has failed.  Retrying in 1 minute.", {error: err});
           node.loop = false
-          timeout = setTimeout(connectConsumer,360000)
+          timeout = setTimeout(connectConsumer,60000)
         })
         .then(function() {
           var deferred = Q.defer();
@@ -190,7 +190,7 @@ module.exports = function(RED) {
 
       instance = new MessageHub(service.getService());
       node.consumerConnected = false
-      timeout = setTimeout(() => {if(!node.consumerConnected)connectConsumer()},360000)
+      timeout = setTimeout(() => {if(!node.consumerConnected)connectConsumer()},300000)
       try {
         instance
           .consume('nodered-' + topic + "-" + random(), 'nodered', { 'auto.offset.reset': 'largest' })
@@ -207,12 +207,12 @@ module.exports = function(RED) {
           .fail(function(error) {
             node.status({fill:"red", shape:"ring", text: error.message});
             node.error('Error creating consumer. Retrying in 1 minute.', {error: error});
-            timeout = setTimeout(connectConsumer,360000)
+            timeout = setTimeout(connectConsumer,60000)
           });
       } catch(e) {
         node.error(e);
         node.status({fill:"red", shape:"ring", text:"Error while consuming.  Retrying in 1 minute."});
-        timeout = setTimeout(connectConsumer,360000)
+        timeout = setTimeout(connectConsumer,60000)
       }
     }
 


### PR DESCRIPTION
At approximately 7:30 AM EST about every day, the connection to IBM Message Hub (now called Event Stream?) is broken.  I created this pull request in order to handle this specifically for the Message Hub consumer.

The events of this disconnection happen as follows in regards to this node and its dependencies:

1. The consumer instance begins to fail to get the topic requested.
2. If the above problem is not resolved, it will simply return this error endlessly until the connection is reset manually.
3. If the above problem is resolved through reconnection within the code itself, a subsequent problem is that the connection may hang endlessly when creating the consumer before topics can be received.

My solution in this pull request is as follows:

1. For the topic errors and for the consumer creation errors, there will be a retry timeout of one minute to restart the process of connecting to IBM message hub.
2.  If creating the consumer takes too long, once again there will be a reconnection timeout, since often the instance gets stuck at some point, unable to receive any kind of HTTP response from IBM during the daily disconnect.
2. This timeout will be cleared if the node is closed.
3. The topic loop is closed if there is an error receiving topics before retrying a connection.